### PR TITLE
Explicitamente cria o diretório /home/bank/Downloads

### DIFF
--- a/warsaw-browser/Dockerfile
+++ b/warsaw-browser/Dockerfile
@@ -38,6 +38,7 @@ RUN apt update \
   && groupadd -g 1000 -r bank \
   && useradd -u 1000 -r -g bank -G audio,video bank \
   && mkdir -p /home/bank \
+  $$ mkdir -p /home/bank/Downloads \
   && chown -R bank:bank /home/bank \
   && echo "bank ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
   && chmod 0440 /etc/sudoers \

--- a/warsaw-browser/Dockerfile
+++ b/warsaw-browser/Dockerfile
@@ -37,8 +37,7 @@ RUN apt update \
   && rm -rf /var/lib/apt/lists/* \
   && groupadd -g 1000 -r bank \
   && useradd -u 1000 -r -g bank -G audio,video bank \
-  && mkdir -p /home/bank \
-  $$ mkdir -p /home/bank/Downloads \
+  && mkdir -p /home/bank/Downloads \
   && chown -R bank:bank /home/bank \
   && echo "bank ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers \
   && chmod 0440 /etc/sudoers \


### PR DESCRIPTION
Atualmente o Firefox reclama de falta de permissão para salvar em Downloads. Criando
explicitamente esse diretório antes do comando de atribuição de permissão corrige o erro